### PR TITLE
(minor) correcting badly formatted test

### DIFF
--- a/ingest_test.go
+++ b/ingest_test.go
@@ -54,7 +54,7 @@ func TestInjest(t *testing.T) {
 								"name": "unit tests",
 							},
 							Error: Error{
-								Message : "foo skip message",
+								Message: "foo skip message",
 							},
 						},
 					},


### PR DESCRIPTION
It was a rogue space in the test. serves me right for not using an IDE with an auto-formatter

I can confirm the branch build is green. Good to go. Sorry about that